### PR TITLE
Fix typos in towns list

### DIFF
--- a/pueblos.json
+++ b/pueblos.json
@@ -138,9 +138,9 @@
     {"nombre": "VILADECANS", "km": 16},
     {"nombre": "VILADECAVALLS", "km": 36},
     {"nombre": "VILAMALLA", "km": 133},
-    {"nombre": "VILASSAR DAlT y MAR", "km": 24},
+    {"nombre": "Vilassar de Dalt i Mar", "km": 24},
     {"nombre": "VILLALBA SASERRA", "km": 44},
-    {"nombre": "VILLANOVA GECTRU", "km": 48},
+    {"nombre": "Vilanova i la Geltrú", "km": 48},
     {"nombre": "Vilobí d'Onyar, Girona", "km": 105}
 ]
 


### PR DESCRIPTION
## Summary
- fix village names in `pueblos.json`

## Testing
- `grep -n "Vilassar de Dalt i Mar" pueblos.json`
- `grep -n "Vilanova i la Geltrú" pueblos.json`


------
https://chatgpt.com/codex/tasks/task_e_68407bdfe7b483329213e84220f302b1