### PR TITLE
Add homepage and persistent history

### DIFF
--- a/calculadora.html
+++ b/calculadora.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cliente SCTRANS</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Cliente SCTRANS</h1>
+        <img src="logo.png" alt="Logo" class="logo">    
+        <div class="row">
+            <!-- Formulario -->
+            <div class="col-md-6">
+                <form id="priceForm">
+                    <div class="form-group">
+                        <label for="distance">Distancia (km):</label>
+                        <input list="pueblos" id="distance" name="distance" required>
+                        <datalist id="pueblos"></datalist>
+                    </div>
+                    <div class="form-group">
+                        <label for="weight">Peso (kg):</label>
+                        <input type="number" id="weight" name="weight" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="volume">Metros Cúbicos:</label>
+                        <input type="number" id="volume" name="volume" step="0.01" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="adr">ADR:</label>
+                        <input type="checkbox" id="adr" name="adr">
+                    </div>
+                    <div class="form-group">
+                        <label for="puertaElevadora">Puerta Elevadora:</label>
+                        <input type="checkbox" id="puertaElevadora" name="puertaElevadora">
+                    </div>
+                    <button type="submit" class="btn btn-primary">Calcular</button>
+                </form>
+                <div id="result"></div>
+            </div>
+
+
+            <!-- Historial -->
+            <div class="col-md-6">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Distancia</th>
+                            <th>Peso</th>
+                            <th>Metros Cúbicos</th>
+                            <th>Cubicaje x 270</th>
+                            <th>Valor Usado</th>
+                            <th>ADR</th>
+                            <th>Puerta Elevadora</th>
+                            <th>Costo Total</th>
+                        </tr>
+                    </thead>
+                    <tbody id="historyBody">
+                        <!-- Aquí se agregarán las filas del historial -->
+                    </tbody>
+                </table>
+                <button id="clearHistory" class="btn btn-danger">Limpiar Historial</button>
+            </div>
+        </div>
+    </div>
+
+    <footer>
+        <p>&copy; 2024 Duvan Guzman. Todos los derechos reservados.</p>
+    </footer>
+
+    <script src="scripts.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,72 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cliente SCTRANS</title>
+    <title>Inicio - Cliente SCTRANS</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <div class="container">
-        <h1>Cliente SCTRANS</h1>
-        <img src="logo.png" alt="Logo" class="logo">    
-        <div class="row">
-            <!-- Formulario -->
-            <div class="col-md-6">
-                <form id="priceForm">
-                    <div class="form-group">
-                        <label for="distance">Distancia (km):</label>
-                        <input list="pueblos" id="distance" name="distance" required>
-                        <datalist id="pueblos"></datalist>
-                    </div>
-                    <div class="form-group">
-                        <label for="weight">Peso (kg):</label>
-                        <input type="number" id="weight" name="weight" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="volume">Metros Cúbicos:</label>
-                        <input type="number" id="volume" name="volume" step="0.01" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="adr">ADR:</label>
-                        <input type="checkbox" id="adr" name="adr">
-                    </div>
-                    <div class="form-group">
-                        <label for="puertaElevadora">Puerta Elevadora:</label>
-                        <input type="checkbox" id="puertaElevadora" name="puertaElevadora">
-                    </div>
-                    <button type="submit" class="btn btn-primary">Calcular</button>
-                </form>
-                <div id="result"></div>
-            </div>
-
-
-            <!-- Historial -->
-            <div class="col-md-6">
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th>Distancia</th>
-                            <th>Peso</th>
-                            <th>Metros Cúbicos</th>
-                            <th>Cubicaje x 270</th>
-                            <th>Valor Usado</th>
-                            <th>ADR</th>
-                            <th>Puerta Elevadora</th>
-                            <th>Costo Total</th>
-                        </tr>
-                    </thead>
-                    <tbody id="historyBody">
-                        <!-- Aquí se agregarán las filas del historial -->
-                    </tbody>
-                </table>
-                <button id="clearHistory" class="btn btn-danger">Limpiar Historial</button>
-            </div>
-        </div>
+        <h1>Bienvenido a SCTRANS</h1>
+        <p>Calcula fácilmente los costes de tu envío con nuestra calculadora.</p>
+        <a href="calculadora.html" class="btn btn-primary">Ir a la Calculadora</a>
     </div>
-
     <footer>
         <p>&copy; 2024 Duvan Guzman. Todos los derechos reservados.</p>
     </footer>
-
-    <script src="scripts.js"></script>
 </body>
 </html>

--- a/scripts.js
+++ b/scripts.js
@@ -22,6 +22,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 pueblosDatalist.appendChild(option);
             });
         });
+
+    // Cargar historial guardado
+    loadHistory();
 });
 
 document.getElementById('priceForm').addEventListener('submit', function(event) {
@@ -64,6 +67,7 @@ document.getElementById('priceForm').addEventListener('submit', function(event) 
 
 document.getElementById('clearHistory').addEventListener('click', function() {
     document.getElementById('historyBody').innerHTML = '';
+    localStorage.removeItem('priceHistory');
 });
 
 function calculatePrice(distance, weight, volume) {
@@ -86,23 +90,40 @@ function findIndex(ranges, value) {
 }
 
 function addHistory(distance, weight, volume, isAdr, isPuertaElevadora, basePrice, adrCost, puertaElevadoraCost, totalPrice) {
+    const data = { distance, weight, volume, isAdr, isPuertaElevadora, basePrice, adrCost, puertaElevadoraCost, totalPrice };
     const historyBody = document.getElementById('historyBody');
+    addHistoryRow(historyBody, data);
+    saveHistoryRow(data);
+}
+
+function addHistoryRow(historyBody, data) {
     const row = document.createElement('tr');
 
-    let cubicWeight = volume * 270;
-    let usedWeight = Math.max(weight, cubicWeight);
-    let usedValue = weight > cubicWeight ? "Peso" : "Metros Cúbicos";
+    let cubicWeight = data.volume * 270;
+    let usedValue = data.weight > cubicWeight ? "Peso" : "Metros Cúbicos";
 
     row.innerHTML = `
-        <td>${distance}</td>
-        <td>${weight}</td>
-        <td>${volume}</td>
+        <td>${data.distance}</td>
+        <td>${data.weight}</td>
+        <td>${data.volume}</td>
         <td>${cubicWeight.toFixed(2)}</td>
         <td>${usedValue}</td>
-        <td>${adrCost.toFixed(2)}</td>
-        <td>${puertaElevadoraCost.toFixed(2)}</td>
-        <td>${totalPrice.toFixed(2)}</td>
+        <td>${data.adrCost.toFixed(2)}</td>
+        <td>${data.puertaElevadoraCost.toFixed(2)}</td>
+        <td>${data.totalPrice.toFixed(2)}</td>
     `;
 
     historyBody.appendChild(row);
+}
+
+function saveHistoryRow(data) {
+    const history = JSON.parse(localStorage.getItem('priceHistory') || '[]');
+    history.push(data);
+    localStorage.setItem('priceHistory', JSON.stringify(history));
+}
+
+function loadHistory() {
+    const history = JSON.parse(localStorage.getItem('priceHistory') || '[]');
+    const historyBody = document.getElementById('historyBody');
+    history.forEach(entry => addHistoryRow(historyBody, entry));
 }


### PR DESCRIPTION
## Summary
- rename `index.html` to `calculadora.html`
- add new `index.html` homepage with link to calculator
- store calculation history in `localStorage`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f2a317ba08332979a32e0b0df169e